### PR TITLE
Fixed numerous warnings generated by Java and Lint.

### DIFF
--- a/res/layout-sw600dp-land/main_activity.xml
+++ b/res/layout-sw600dp-land/main_activity.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent">
     <!-- The main content view -->
     <LinearLayout 
+        android:baselineAligned="false"
         android:orientation="horizontal"
         android:layout_width="match_parent"
 	    android:layout_height="match_parent">

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -131,7 +131,7 @@
   <string name="dialog_close">Schließen</string>
   <string name="error_versions">Inkompatible Version</string>
   <string name="old_proto">Bitte Clementine updaten!</string>
-  <string name="no_private_ip">Dein Android Gerät hat eine nicht lokale IP Addresse. Deaktiviere \"Akzeptiere nur lokale Clients\" in den Clementine Einstellungen.</string>
+  <string name="no_private_ip">Dein Android Gerät hat eine nicht lokale IP Adresse. Deaktiviere \"Akzeptiere nur lokale Clients\" in den Clementine Einstellungen.</string>
   <string name="check_ip">1) Läuft Clementine?\n2) Nutzt du Clementine 1.2.1 oder höher?\n3) Hast du die Netzwerkfernsteuerung in den Clementine-Einstellungen aktiviert?\n4) Prüfe, ob die IP Adresse korrekt ist.</string>
   <string name="wifi_disabled">Wifi ist deaktiviert. Wenn du über das Internet Clementine fernsteuern möchtest, stelle sicher, dass du die Ports korrekt weitergeleitet hast und \"Akzeptiere nur lokale Clients\" deaktiviert ist.</string>
   <string name="input_auth_code">Authentifizierungs-Code</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,10 +6,8 @@
     
     <string name="connectdialog_connect">Connect</string>
     <string name="connectdialog_autoconnect">Auto-Connect</string>
-    <string name="connectdialog_clementine_found">Found Clementine!</string>
     <string name="connectdialog_connecting">Connecting to Clementine</string>
     <string name="connectdialog_download_data">Downloading data</string>
-    <string name="connectdialog_connected">Connected</string>
     <string name="connectdialog_error">Could not reach host</string>
     <string name="connectdialog_ip_hint">Enter IP address</string>
     <string name="connectdialog_mdns_found">Found Clementines. Touch the icon to choose one.</string>
@@ -54,8 +52,6 @@
     <string name="library_download">Downloading library</string>
     <string name="library_optimize">Optimizing database</string>
     <string name="library_please_wait">Please wait</string>
-    <string name="library_search_hint">Search library</string>
-    <string name="library_loading">Loading</string>
     <string name="library_refresh">Refresh</string>
     <string name="library_empty">Library empty. Hit refresh to download library!</string>
     <string name="library_no_albums">%d albums</string>
@@ -81,9 +77,7 @@
     <string name="menu_shuffle">Shuffle</string>
     <string name="menu_repeat">Repeat</string>
     <string name="menu_settings">Settings</string>
-    <string name="menu_playlist">Playlists</string>
     <string name="menu_search">Search</string>
-    <string name="menu_disconnect">Disconnect</string>
     <string name="menu_love">Love</string>
     <string name="menu_ban">Ban</string>
     <string name="menu_download_song">Download song</string>

--- a/src/de/qspool/clementineremote/ClementineExceptionHandler.java
+++ b/src/de/qspool/clementineremote/ClementineExceptionHandler.java
@@ -23,7 +23,7 @@ import java.io.PrintWriter;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -91,6 +91,7 @@ public class ClementineExceptionHandler implements UncaughtExceptionHandler {
 	 * Builds the filename for the stacktrace file (/data/data/de.qspool....)
 	 * @return The filename with path as a string
 	 */
+	@SuppressLint("SimpleDateFormat")
 	private String buildTraceFileName() {
 		SimpleDateFormat ft = 
 			      new SimpleDateFormat ("yyyy.MM.dd-hh:mm:ss");

--- a/src/de/qspool/clementineremote/backend/ClementineLibraryDownloader.java
+++ b/src/de/qspool/clementineremote/backend/ClementineLibraryDownloader.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import de.qspool.clementineremote.App;

--- a/src/de/qspool/clementineremote/ui/ClementineSettings.java
+++ b/src/de/qspool/clementineremote/ui/ClementineSettings.java
@@ -69,6 +69,9 @@ public class ClementineSettings extends SherlockPreferenceActivity
 	private Preference mDownloadDir;
 	private Preference mClementine;
 	
+	//suppress warnings about deprecation as we intend to support
+	//Android API 8 which requires the deprecated methods.
+	@SuppressWarnings("deprecation")
 	@Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/src/de/qspool/clementineremote/ui/ConnectDialog.java
+++ b/src/de/qspool/clementineremote/ui/ConnectDialog.java
@@ -40,7 +40,6 @@ import android.preference.PreferenceManager;
 import android.text.InputType;
 import android.util.Log;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.View.OnClickListener;
 import android.view.Window;
 import android.view.WindowManager.LayoutParams;

--- a/src/de/qspool/clementineremote/ui/FileDialog.java
+++ b/src/de/qspool/clementineremote/ui/FileDialog.java
@@ -5,6 +5,7 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -147,7 +148,7 @@ public class FileDialog {
                     if (!sel.canRead()) return false;
                     if (selectDirectoryOption) return sel.isDirectory();
                     else {
-                        boolean endsWith = fileEndsWith != null ? filename.toLowerCase().endsWith(fileEndsWith) : true;
+                        boolean endsWith = fileEndsWith != null ? filename.toLowerCase(Locale.getDefault()).endsWith(fileEndsWith) : true;
                         return endsWith || sel.isDirectory();
                     }
                 }
@@ -168,7 +169,7 @@ public class FileDialog {
     }
 
     public void setFileEndsWith(String fileEndsWith) {
-        this.fileEndsWith = fileEndsWith != null ? fileEndsWith.toLowerCase() : fileEndsWith;
+        this.fileEndsWith = fileEndsWith != null ? fileEndsWith.toLowerCase(Locale.getDefault()) : fileEndsWith;
     }
  }
 

--- a/src/de/qspool/clementineremote/utils/IabException.java
+++ b/src/de/qspool/clementineremote/utils/IabException.java
@@ -22,7 +22,9 @@ package de.qspool.clementineremote.utils;
  * call {@link #getResult()}.
  */
 public class IabException extends Exception {
-    IabResult mResult;
+
+	private static final long serialVersionUID = -7076371973656036636L;
+	IabResult mResult;
 
     public IabException(IabResult r) {
         this(r, null);

--- a/src/de/qspool/clementineremote/utils/Security.java
+++ b/src/de/qspool/clementineremote/utils/Security.java
@@ -18,10 +18,6 @@ package de.qspool.clementineremote.utils;
 import android.text.TextUtils;
 import android.util.Log;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;


### PR DESCRIPTION
Added baselineAligned option to main_activity.xml as suggested by Lint to increase performance.
Fixed spelling error in values-de/strings.xml (this maybe should be done on transifex?)
Removed several unused strings from values/strings.xml
Added suppression for Lint warning to ClementineExceptionHandler.java since hard-coding the date here is fine for debugging purposes.
Removed unused imports from ClementineLibraryDownloader.java, ConnectDialog.java and Security.java
Added warning suppression to ClementineSettings.java since deprecated methods will be removed during later refactoring.
Added locale-specific method calls to FileDialog.java to fix potential locale-specific bugs.
Added serialVersionUID to IabException.java to remove java warning about serializable interfaces.
