### PR TITLE
ListView clipToPadding, scroll view indicator

### DIFF
--- a/app/res/layout/fragment_downloads.xml
+++ b/app/res/layout/fragment_downloads.xml
@@ -6,9 +6,9 @@
 
     <ListView
             android:id="@+id/downloads"
+            style="@style/ContentListView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@drawable/white_background"/>
+            android:layout_height="match_parent" />
 
     <RelativeLayout
             android:id="@+id/downloads_empty"

--- a/app/res/layout/fragment_library.xml
+++ b/app/res/layout/fragment_library.xml
@@ -6,7 +6,7 @@
 
     <ListView
         android:id="@+id/library"
-        android:background="@drawable/white_background"
+        style="@style/ContentListView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/app/res/layout/fragment_playlist.xml
+++ b/app/res/layout/fragment_playlist.xml
@@ -6,7 +6,7 @@
 
     <ListView
         android:id="@+id/songs"
-        android:background="@drawable/white_background"
+        style="@style/ContentListView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -92,4 +92,10 @@
     <style name="ShowcaseView.Detail" parent="android:style/TextAppearance">
         <item name="android:textColor">@color/white</item>
     </style>
+
+    <style name="ContentListView">
+        <item name="android:background">@drawable/white_background</item>
+        <item name="android:clipToPadding">false</item>
+        <item name="android:scrollbarStyle">outsideOverlay</item>
+    </style>
 </resources>


### PR DESCRIPTION
Some suggested tweaks to listview appearance:
* List content for the downloads, playlist and library fragments no longer clipped by padding while scrolling
* Scrollbar indicator no longer overlaps row content

This is done by setting the `android:clipToPadding` and `android:scrollbarStyle` XML layout attributes for the listviews

Ref: https://plus.google.com/+AndroidDevelopers/posts/LpAA7q4jw9M

**Before:**
![device-2015-02-08-153328](https://cloud.githubusercontent.com/assets/5158190/6094951/a61f26a8-afa8-11e4-9f4a-d11591a408f5.png)

**After:**
![device-2015-02-08-153425](https://cloud.githubusercontent.com/assets/5158190/6094953/afaaacb0-afa8-11e4-84c3-a2ea5467f7a2.png)
