### PR TITLE
Add the possibility to order the albums by release date in the library

### DIFF
--- a/app/src/main/java/de/qspool/clementineremote/SharedPreferencesKeys.java
+++ b/app/src/main/java/de/qspool/clementineremote/SharedPreferencesKeys.java
@@ -43,6 +43,8 @@ public class SharedPreferencesKeys {
 
     public final static String SP_VOLUME_INC = "pref_volume_inc";
 
+    public final static String SP_LIBRARY_ALBUM_ORDER = "pref_library_album_order";
+
     public final static String SP_WIFI_ONLY = "pref_dl_wifi_only";
 
     public final static String SP_DOWNLOAD_DIR = "pref_dl_dir";

--- a/app/src/main/java/de/qspool/clementineremote/ui/adapter/LibraryAdapter.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/adapter/LibraryAdapter.java
@@ -29,6 +29,7 @@ import android.widget.TextView;
 import de.qspool.clementineremote.R;
 import de.qspool.clementineremote.backend.player.MyLibrary;
 import de.qspool.clementineremote.backend.player.MyLibraryItem;
+import de.qspool.clementineremote.ui.settings.LibraryAlbumOrder;
 
 /**
  * Class is used for displaying the song data
@@ -41,13 +42,17 @@ public class LibraryAdapter extends CursorAdapter implements Filterable {
 
     private int mLevel;
 
+    private LibraryAlbumOrder mAlbumOrder;
+
     private String mUnknownItem;
 
-    public LibraryAdapter(Context context, Cursor c, MyLibrary library, int level) {
+
+    public LibraryAdapter(Context context, Cursor c, MyLibrary library, int level, LibraryAlbumOrder albumOrder) {
         super(context, c, false);
         mContext = context;
         mLibrary = library;
         mLevel = level;
+        mAlbumOrder = albumOrder;
         mUnknownItem = mContext.getString(R.string.library_unknown_item);
     }
 
@@ -86,7 +91,12 @@ public class LibraryAdapter extends CursorAdapter implements Filterable {
                 if (cursor.getString(MyLibrary.IDX_ALBUM).isEmpty()) {
                     libraryViewHolder.title.setText(mUnknownItem);
                 } else {
-                    libraryViewHolder.title.setText(cursor.getString(MyLibrary.IDX_ALBUM));
+                    if (LibraryAlbumOrder.RELEASE.equals(mAlbumOrder)) {
+                        String albumTitleWithYear = getAlbumTitleWithYearAsPrefix(cursor);
+                        libraryViewHolder.title.setText(albumTitleWithYear);
+                    } else {
+                        libraryViewHolder.title.setText(cursor.getString(MyLibrary.IDX_ALBUM));
+                    }
                 }
                 libraryViewHolder.subtitle.setText(String.format(
                         mContext.getString(R.string.library_no_tracks),
@@ -109,6 +119,21 @@ public class LibraryAdapter extends CursorAdapter implements Filterable {
             default:
                 break;
         }
+    }
+
+    /**
+     * Checks if a cursor holds a valid release year and puts it in front of the album title.
+     * If successful, it looks like: "2015 - My Album Title", otherwise: "My Album Title". This is
+     * the same behavior like in the desktop client.
+     * @return The formatted title
+     */
+    private String getAlbumTitleWithYearAsPrefix(Cursor cursor) {
+        String albumTitleWithYear = cursor.getString(MyLibrary.IDX_ALBUM);
+        int releaseYear = cursor.getInt(MyLibrary.IDX_YEAR);
+        if (releaseYear > 0) {
+            albumTitleWithYear = releaseYear + " - " + albumTitleWithYear;
+        }
+        return albumTitleWithYear;
     }
 
     @Override

--- a/app/src/main/java/de/qspool/clementineremote/ui/settings/ClementineSettings.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/settings/ClementineSettings.java
@@ -91,6 +91,9 @@ public class ClementineSettings extends PreferenceActivity {
         if (PreferencesBehaviorPlayer.class.getName().equals(fragmentName)) {
             return true;
         }
+        if (PreferencesBehaviorLibrary.class.getName().equals(fragmentName)) {
+            return true;
+        }
         if (PreferencesBehaviorDownloads.class.getName().equals(fragmentName)) {
             return true;
         }

--- a/app/src/main/java/de/qspool/clementineremote/ui/settings/LibraryAlbumOrder.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/settings/LibraryAlbumOrder.java
@@ -1,0 +1,29 @@
+/* This file is part of the Android Clementine Remote.
+ * Copyright (C) 2013, Andreas Muttscheller <asfa194@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package de.qspool.clementineremote.ui.settings;
+
+/**
+ * This enum represents the specified sort order for albums in the LibraryFragment
+ * configured by the PreferencesBehaviorLibrary.
+ * These values must correspond with the string-array pref_library_album_order_values, otherwise
+ * type casts will fail.
+ */
+public enum LibraryAlbumOrder {
+    ALPHABET,
+    RELEASE
+}

--- a/app/src/main/java/de/qspool/clementineremote/ui/settings/PreferencesBehaviorLibrary.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/settings/PreferencesBehaviorLibrary.java
@@ -1,0 +1,32 @@
+/* This file is part of the Android Clementine Remote.
+ * Copyright (C) 2013, Andreas Muttscheller <asfa194@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package de.qspool.clementineremote.ui.settings;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+import de.qspool.clementineremote.R;
+
+public class PreferencesBehaviorLibrary extends PreferenceFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.preference_library);
+    }
+}

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -60,4 +60,11 @@
         <item>19</item>
         <item>20</item>
     </string-array>
+
+    <!-- These strings are used in preference_library.xml and the
+    Java class LibraryAlbumOrder -->
+    <string-array name="pref_library_album_order_values">
+        <item>alphabet</item>
+        <item>release</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
 
     <string name="pref_cat_behavior">Behavior</string>
     <string name="pref_cat_player">Player</string>
+    <string name="pref_cat_library">Library</string>
     <string name="pref_cat_downloads">Downloads</string>
     <string name="pref_cat_advanced">Advanced</string>
     <string name="pref_cat_network">Network</string>
@@ -136,6 +137,13 @@
     <string name="pref_call_volume_summary">Current call volume level: %s</string>
     <string name="pref_volume_inc_title">Volume change level</string>
     <string name="pref_volume_inc_summary">Current volume change level : %s</string>
+
+    <string name="pref_library_album_order_title">Album sorting</string>
+    <string name="pref_library_album_order_summary">The albums in the library are currently sorted by %1$s.</string>
+    <string-array name="pref_library_album_order_display">
+        <item>Alphabet</item>
+        <item>Release</item>
+    </string-array>
 
     <string name="pref_autoconnect_title">Auto-Connect</string>
     <string name="pref_autoconnect_summary">Automatically connect to Clementine when starting the remote.

--- a/app/src/main/res/xml/preference_headers.xml
+++ b/app/src/main/res/xml/preference_headers.xml
@@ -5,6 +5,8 @@
 
     <header android:fragment="de.qspool.clementineremote.ui.settings.PreferencesBehaviorPlayer"
             android:title="@string/pref_cat_player"/>
+    <header android:fragment="de.qspool.clementineremote.ui.settings.PreferencesBehaviorLibrary"
+        android:title="@string/pref_cat_library"/>
     <header android:fragment="de.qspool.clementineremote.ui.settings.PreferencesBehaviorDownloads"
             android:title="@string/pref_cat_downloads"/>
     <header android:fragment="de.qspool.clementineremote.ui.settings.PreferencesBehaviorAdvanced"

--- a/app/src/main/res/xml/preference_library.xml
+++ b/app/src/main/res/xml/preference_library.xml
@@ -1,0 +1,16 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  android:title="@string/pref_cat_library">
+
+    <!-- Allows the user to specify the sort order for albums in the LibraryFragment.
+         Like in the desktop client the default value for sorting is alphabetical.
+     -->
+    <ListPreference
+        android:key="pref_library_album_order"
+        android:title="@string/pref_library_album_order_title"
+        android:summary="@string/pref_library_album_order_summary"
+        android:entries="@array/pref_library_album_order_display"
+        android:entryValues="@array/pref_library_album_order_values"
+        android:defaultValue="alphabet"
+    />
+
+</PreferenceScreen>


### PR DESCRIPTION
Hello guys,

I really like clementine and the android remote client, but it always bothered me that albums are displayed in alphabetical order instead of chronological order. I'd be happy if you would merge this commit asap, so it's in the next release of the app. :)

You might want to check, if this line is okay, cause I could not figure out what IDX_COUNT is used for and I am using the same index.
https://github.com/peah90/Android-Remote/commit/0591dfd8c97fec400de8e15c7484ee442c5c3c5c#diff-c38c2e3c499a4a6cda2287f77fae257cR64

Best Regards,
Daniel

<b>Commit-Message:</b>
"Fixes #114.

This commit allows the user to select between "alphabet" and "release" in the preferences for the default ordering for albums in the LibraryFragment.
The default setting is "alphabet".

If the albums are sorted by release, the release year is added as prefix in front of the album title, like: "2015 - Album title".
In case of alphabetical ordering just the album title is displayed.

If an artist is added to Clementine's playlist, this setting is respected (therefore the titles are added by release year or alphabet)."