### PR TITLE
Modernize ActionBar with Lollipop-style Toolbar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile 'com.android.support:support-v13:22.0.0'
-    compile 'com.android.support:support-v4:22.0.0'
     compile 'com.android.support:appcompat-v7:22.0.0'
     compile 'com.google.protobuf:protobuf-java:2.5.0'
     compile 'javax.jmdns:jmdns:3.4.1'

--- a/app/src/main/java/de/qspool/clementineremote/ui/ConnectDialog.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/ConnectDialog.java
@@ -40,6 +40,8 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Message;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
 import android.text.InputType;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -87,7 +89,7 @@ import de.qspool.clementineremote.utils.Utilities;
 /**
  * The connect dialog
  */
-public class ConnectDialog extends Activity {
+public class ConnectDialog extends ActionBarActivity {
 
     private final int ANIMATION_DURATION = 2000;
 
@@ -136,8 +138,6 @@ public class ConnectDialog extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_connectdialog);
-
-        getActionBar().setDisplayHomeAsUpEnabled(false);
 
         mSharedPref = PreferenceManager.getDefaultSharedPreferences(this);
         mKnownIps = mSharedPref
@@ -252,6 +252,8 @@ public class ConnectDialog extends Activity {
     }
 
     private void initializeUi() {
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
         // Get the Layoutelements
         mBtnConnect = (Button) findViewById(R.id.btnConnect);
         mBtnConnect.setOnClickListener(oclConnect);

--- a/app/src/main/java/de/qspool/clementineremote/ui/MainActivity.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/MainActivity.java
@@ -17,7 +17,6 @@
 
 package de.qspool.clementineremote.ui;
 
-import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
@@ -29,7 +28,9 @@ import android.os.Handler;
 import android.os.Message;
 import android.preference.PreferenceManager;
 import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MenuItem;
@@ -62,7 +63,7 @@ import de.qspool.clementineremote.ui.interfaces.RemoteDataReceiver;
 import de.qspool.clementineremote.ui.settings.ClementineSettings;
 import de.qspool.clementineremote.utils.Utilities;
 
-public class MainActivity extends Activity {
+public class MainActivity extends ActionBarActivity {
 
     private final static String MENU_POSITION = "last_menu_position";
 
@@ -114,6 +115,8 @@ public class MainActivity extends Activity {
         mFragments.add(new DownloadsFragment());
         mFragments.add(new DonateFragment());
 
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
         mDrawerList = (ListView) findViewById(R.id.left_drawer);
 
         if (findViewById(R.id.player_frame) != null) {
@@ -157,8 +160,8 @@ public class MainActivity extends Activity {
         // Set the drawer toggle as the DrawerListener
         mDrawerLayout.setDrawerListener(mDrawerToggle);
 
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
 
         mSharedPref = PreferenceManager.getDefaultSharedPreferences(this);
 

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/DonateFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/DonateFragment.java
@@ -17,10 +17,11 @@
 
 package de.qspool.clementineremote.ui.fragments;
 
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -105,7 +106,7 @@ public class DonateFragment extends Fragment implements BackPressHandleable, Rem
         mDonateTwo.setOnClickListener(oclDonate);
         mDonateFive.setOnClickListener(oclDonate);
 
-        mActionBar = getActivity().getActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
         mActionBar.setTitle("");
         mActionBar.setSubtitle("");
 

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/DownloadsFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/DownloadsFragment.java
@@ -17,13 +17,14 @@
 
 package de.qspool.clementineremote.ui.fragments;
 
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -66,7 +67,7 @@ public class DownloadsFragment extends Fragment implements BackPressHandleable, 
         super.onCreate(savedInstanceState);
 
         // Get the actionbar
-        mActionBar = getActivity().getActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
         setHasOptionsMenu(true);
     }
 

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/LibraryFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/LibraryFragment.java
@@ -18,7 +18,6 @@
 package de.qspool.clementineremote.ui.fragments;
 
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.app.ProgressDialog;
 import android.content.SharedPreferences;
@@ -27,6 +26,8 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Message;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
 import android.util.SparseBooleanArray;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
@@ -95,7 +96,7 @@ public class LibraryFragment extends Fragment implements BackPressHandleable, Re
         super.onCreate(savedInstanceState);
 
         // Get the actionbar
-        mActionBar = getActivity().getActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
         setHasOptionsMenu(true);
 
         mUnknownItem = getString(R.string.library_unknown_item);

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/PlayerFragment.java
@@ -18,14 +18,15 @@
 package de.qspool.clementineremote.ui.fragments;
 
 import com.github.amlcurran.showcaseview.ShowcaseView;
-import com.github.amlcurran.showcaseview.targets.ActionViewTarget;
 import com.github.amlcurran.showcaseview.targets.ViewTarget;
 
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.os.Message;
 import android.support.v4.view.ViewPager;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -79,7 +80,7 @@ public class PlayerFragment extends Fragment implements BackPressHandleable, Rem
         super.onActivityCreated(savedInstanceState);
 
         // Get the actionbar
-        mActionBar = getActivity().getActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
         mActionBar.setTitle(R.string.player_playlist);
     }
 
@@ -251,7 +252,7 @@ public class PlayerFragment extends Fragment implements BackPressHandleable, Rem
     public void showShowcase() {
         final ShowcaseView sv = new ShowcaseView.Builder(getActivity())
                 .setStyle(R.style.ShowcaseTheme)
-                .setTarget(new ActionViewTarget(getActivity(), ActionViewTarget.Type.HOME))
+                .setTarget(new ViewTarget(((Toolbar) getActivity().findViewById(R.id.toolbar)).getChildAt(0)))
                 .setContentTitle(R.string.cm_player_home_title)
                 .setContentText(R.string.cm_player_home_content)
                 .build();

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/PlaylistFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/PlaylistFragment.java
@@ -17,12 +17,13 @@
 
 package de.qspool.clementineremote.ui.fragments;
 
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.app.ProgressDialog;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Message;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.ActionBarActivity;
 import android.util.SparseBooleanArray;
 import android.view.ActionMode;
 import android.view.ContextMenu;
@@ -93,7 +94,7 @@ public class PlaylistFragment extends Fragment implements BackPressHandleable, R
         super.onCreate(savedInstanceState);
 
         // Get the actionbar
-        mActionBar = getActivity().getActionBar();
+        mActionBar = ((ActionBarActivity) getActivity()).getSupportActionBar();
         mActionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
         setHasOptionsMenu(true);
 

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/playerpages/PlayerPageFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/playerpages/PlayerPageFragment.java
@@ -18,7 +18,6 @@
 package de.qspool.clementineremote.ui.fragments.playerpages;
 
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.app.ProgressDialog;
 import android.graphics.Bitmap;
@@ -86,8 +85,6 @@ public class PlayerPageFragment extends Fragment
 
     private boolean mCoverUpdated = false;
 
-    private ActionBar mActionBar;
-
     MenuItem mMenuRepeat;
 
     MenuItem mMenuShuffle;
@@ -104,9 +101,6 @@ public class PlayerPageFragment extends Fragment
     public void onCreate(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        // Get the actionbar
-        mActionBar = getActivity().getActionBar();
-        mActionBar.setTitle(R.string.player_playlist);
         setHasOptionsMenu(true);
     }
 

--- a/app/src/main/java/de/qspool/clementineremote/ui/fragments/playerpages/SongDetailFragment.java
+++ b/app/src/main/java/de/qspool/clementineremote/ui/fragments/playerpages/SongDetailFragment.java
@@ -22,7 +22,6 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
-import android.app.ActionBar;
 import android.app.Fragment;
 import android.content.SharedPreferences;
 import android.graphics.Point;
@@ -101,8 +100,6 @@ public class SongDetailFragment extends Fragment
 
     private SharedPreferences mSharedPref;
 
-    private ActionBar mActionBar;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -118,8 +115,6 @@ public class SongDetailFragment extends Fragment
             Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_player_songdetail,
                 container, false);
-
-        mActionBar = getActivity().getActionBar();
 
         mContainer = (FrameLayout) view.findViewById(R.id.si_container);
 

--- a/app/src/main/res/layout-land/activity_connectdialog.xml
+++ b/app/src/main/res/layout-land/activity_connectdialog.xml
@@ -6,6 +6,8 @@
     android:orientation="horizontal"
     android:paddingBottom="30dp">
 
+    <include layout="@layout/toolbar" />
+
     <ImageButton
         android:id="@+id/btnClementineIcon"
         android:layout_width="wrap_content"
@@ -19,6 +21,7 @@
         android:layout_weight="1"
         android:background="@android:color/transparent"
         android:contentDescription="@string/connect_desc_icon"
+        android:paddingTop="?attr/actionBarSize"
         android:scaleType="fitCenter"
         android:src="@drawable/icon_large" />
 

--- a/app/src/main/res/layout-sw600dp-land/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp-land/activity_main.xml
@@ -4,26 +4,36 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <!-- The main content view -->
-    <LinearLayout
-        android:baselineAligned="false"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <RelativeLayout
+        android:layout_height="match_parent"
+        android:layout_width="match_parent">
 
-        <FrameLayout
-            android:id="@+id/player_frame"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="left"
-            android:layout_weight="1" />
+        <include
+            layout="@layout/toolbar"
+            android:id="@+id/toolbar" />
 
-        <FrameLayout
-            android:id="@+id/content_frame"
+        <LinearLayout
+            android:baselineAligned="false"
+            android:orientation="horizontal"
+            android:layout_below="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="right"
-            android:layout_weight="1" />
-    </LinearLayout>
+            android:layout_height="match_parent">
+
+            <FrameLayout
+                android:id="@+id/player_frame"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="left"
+                android:layout_weight="1" />
+
+            <FrameLayout
+                android:id="@+id/content_frame"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="right"
+                android:layout_weight="1" />
+        </LinearLayout>
+    </RelativeLayout>
     <!-- The navigation drawer -->
     <ListView
         android:id="@+id/left_drawer"

--- a/app/src/main/res/layout/activity_connectdialog.xml
+++ b/app/src/main/res/layout/activity_connectdialog.xml
@@ -6,6 +6,8 @@
     android:orientation="vertical"
     android:paddingBottom="30dp">
 
+    <include layout="@layout/toolbar" />
+
     <ImageButton
         android:id="@+id/btnClementineIcon"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,11 +4,21 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <!-- The main content view -->
-    <FrameLayout
-        android:id="@+id/content_frame"
-        android:layout_width="match_parent"
+    <RelativeLayout
         android:layout_height="match_parent"
-        android:padding="7dp"/>
+        android:layout_width="match_parent">
+
+        <include
+            layout="@layout/toolbar"
+            android:id="@+id/toolbar" />
+
+        <FrameLayout
+            android:id="@+id/content_frame"
+            android:layout_below="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="7dp" />
+    </RelativeLayout>
     <!-- The navigation drawer -->
     <ListView
         android:id="@+id/left_drawer"

--- a/app/src/main/res/layout/fragment_player_control.xml
+++ b/app/src/main/res/layout/fragment_player_control.xml
@@ -97,6 +97,7 @@
         android:layout_marginTop="5dp"
         android:maxHeight="5dp"
         android:progressDrawable="@drawable/progress"
+        android:splitTrack="false"
         android:thumb="@drawable/scrubber_control" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+</android.support.v7.widget.Toolbar>

--- a/app/src/main/res/menu/library_menu.xml
+++ b/app/src/main/res/menu/library_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/library_menu_search"
-        android:actionViewClass="android.widget.SearchView"
+        app:actionViewClass="android.widget.SearchView"
         android:icon="@drawable/ab_search"
         app:showAsAction="ifRoom|collapseActionView"
         android:title="@string/menu_search"></item>

--- a/app/src/main/res/menu/playlist_menu.xml
+++ b/app/src/main/res/menu/playlist_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/playlist_menu_search"
-        android:actionViewClass="android.widget.SearchView"
+        app:actionViewClass="android.widget.SearchView"
         android:icon="@drawable/ab_search"
         app:showAsAction="ifRoom|collapseActionView"
         android:title="@string/menu_search"></item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="actionbar_border">#edb49b</color>
     <color name="actionbar">#db6835</color>
+    <color name="actionbar_dark">#bb5325</color>
 
     <color name="clementine_right">#db6835</color>
     <color name="clementine_left">#af597d</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,15 +27,16 @@
         <item name="android:actionBarStyle">@style/ActionBarStyle</item>
     </style>
 
-    <style name="PlayerTheme" parent="@android:style/Theme.Holo.Light">
-        <item name="android:actionBarStyle">@style/ActionBarStyle</item>
-        <item name="android:actionButtonStyle">@style/ActionButtonStyle</item>
+    <style name="PlayerTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/actionbar</item>
+        <item name="colorPrimaryDark">@color/actionbar_dark</item>
         <item name="android:actionModeBackground">@drawable/cab_background_top_example</item>
         <item name="android:actionModeSplitBackground">@drawable/cab_background_bottom_example
         </item>
         <item name="android:activatedBackgroundIndicator">@drawable/selector_white_orange_selected
         </item>
         <item name="android:spinnerItemStyle">@style/SpinnerItem</item>
+        <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItem</item>
         <item name="android:actionOverflowButtonStyle">
             @android:style/Widget.Holo.ActionButton.Overflow
         </item>
@@ -76,6 +77,11 @@
 
     <style name="SpinnerItem" parent="@android:style/Widget.Holo.TextView.SpinnerItem">
         <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="SpinnerDropDownItem" parent="@android:style/Widget.Holo.DropDownItem.Spinner">
+        <item name="android:textColor">@color/black</item>
+        <item name="android:background">@color/white</item>
     </style>
 
     <style name="ShowcaseTheme" parent="ShowcaseView.Light">


### PR DESCRIPTION
This replaces the ActionBar with a new standard [Toolbar](https://developer.android.com/reference/android/widget/Toolbar.html).
The main app theme now extends `Theme.AppCompat.Light.NoActionBar` instead of `Theme.Holo.Light`.
Fixes #124 (hidden action buttons) that broke with c7abe2848a0b4f99126f99eff75a24e98167d74e
@amuttsch The navigation drawer is currently drawn **below** the toolbar (just like before). The Google design guidelines recommend it should overlay the toolbar/action bar. What is your preference?

![clementine-remote-01](https://cloud.githubusercontent.com/assets/743291/7177647/2fa2078e-e3dd-11e4-86d5-def9f78ed7a5.png) ![clementine-remote-02](https://cloud.githubusercontent.com/assets/743291/7177651/32116ba4-e3dd-11e4-8a48-145e67695e57.png)
