### PR TITLE
Update Gradle plug-in and wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 10 16:33:41 SGT 2016
+#Thu Apr 28 13:10:40 SGT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip


### PR DESCRIPTION
This updates the Android Gradle plug-in to `2.1.0` and Gradle wrapper to `2.13`.