### PR TITLE
[Bug] Missing "Album artist-album" French translation

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -130,6 +130,7 @@
   <string-array name="pref_library_grouping">
     <item>Artiste</item>
     <item>Artiste / Album</item>
+    <item>Artiste d'album / Album</item>
     <item>Artiste / Année</item>
     <item>Album</item>
     <item>Genre / Album</item>


### PR DESCRIPTION
In French, on of the `pref_library_grouping_values` translation is missing, the one for `albumartist-album`.

Hence, the options don't correspond to the correct grouping features of the library, and the last option is also missing.

Looking at the `/app/src/main/res/values/array.xml` file, there should be 7 options in the following order :

    <string-array name="pref_library_grouping_values">
            <item>artist</item>
            <item>artist-album</item>
            <item>albumartist-album</item>
            <item>artist-year</item>
            <item>album</item>
            <item>genre-album</item>
            <item>genre-artist-album</item>
    </string-array>

I think that this problem is present in others languages too where I can only see 6 options. Not sure my pull request answer the issue completely, I have never looked into how translations work.